### PR TITLE
Remove MS-SSIM video quality metric calculation

### DIFF
--- a/common.go
+++ b/common.go
@@ -194,3 +194,17 @@ func fileExists(p string) bool {
 
 	return true
 }
+
+func all[T comparable](s []T, val T) bool {
+	if len(s) == 0 {
+		return false
+	}
+
+	for _, e := range s {
+		if e != val {
+			return false
+		}
+	}
+
+	return true
+}

--- a/common_test.go
+++ b/common_test.go
@@ -66,3 +66,80 @@ func Test_report_WriteJSON(t *testing.T) {
 
 	assert.Equal(t, wantStr, got.String())
 }
+
+func Test_all_Positive(t *testing.T) {
+	floatTests := map[string]struct {
+		given []float64
+		cmp   float64
+		want  bool
+	}{
+		"all match": {
+			given: []float64{1.0, 1.0, 1.0, 1.0},
+			cmp:   1,
+			want:  true,
+		},
+		"some don't match": {
+			given: []float64{1, 0.9999999999, 1, 1},
+			cmp:   1,
+			want:  false,
+		},
+		"empty slice": {
+			given: []float64{},
+			cmp:   0,
+			want:  false,
+		},
+		"nil slice": {
+			given: nil,
+			cmp:   0,
+			want:  false,
+		},
+	}
+
+	stringTests := map[string]struct {
+		cmp   string
+		given []string
+		want  bool
+	}{
+		"all match": {
+			given: []string{"foo", "foo", "foo"},
+			cmp:   "foo",
+			want:  true,
+		},
+		"some don't match": {
+			given: []string{"foo", "foo", "bar", "foo", "baz"},
+			cmp:   "foo",
+			want:  false,
+		},
+		"empty strings": {
+			given: []string{"", "", ""},
+			cmp:   "",
+			want:  true,
+		},
+		"empty slice": {
+			given: []string{},
+			cmp:   "",
+			want:  false,
+		},
+		"nil slice": {
+			given: nil,
+			cmp:   "",
+			want:  false,
+		},
+	}
+
+	t.Run("float type tests", func(t *testing.T) {
+		for name, tc := range floatTests {
+			t.Run(name, func(t *testing.T) {
+				assert.Equal(t, tc.want, all(tc.given, tc.cmp))
+			})
+		}
+	})
+
+	t.Run("string type tests", func(t *testing.T) {
+		for name, tc := range stringTests {
+			t.Run(name, func(t *testing.T) {
+				assert.Equal(t, tc.want, all(tc.given, tc.cmp))
+			})
+		}
+	})
+}

--- a/ease_test.go
+++ b/ease_test.go
@@ -41,9 +41,6 @@ func Test_RunApp_Run(t *testing.T) {
 
 	psnrPlots, _ := filepath.Glob(fmt.Sprintf("%s/*/*psnr.png", outDir))
 	assert.Len(t, psnrPlots, 1, "Expecting one file for PSNR plot")
-
-	msssimPlots, _ := filepath.Glob(fmt.Sprintf("%s/*/*ms-ssim.png", outDir))
-	assert.Len(t, msssimPlots, 1, "Expecting one file for MS-SSIM plot")
 }
 
 /*************************************

--- a/internal/vqm/vqm.go
+++ b/internal/vqm/vqm.go
@@ -22,7 +22,7 @@ import (
 )
 
 var DefaultFfmpegVMAFTemplate = "-hide_banner -i {{.CompressedFile}} -i {{.SourceFile}} " +
-	"-lavfi libvmaf=n_subsample=1:log_path={{.ResultFile}}:ms_ssim=1:psnr=1:log_fmt=json:model_path={{.ModelPath}}:n_threads={{.NThreads}} -f null -"
+	"-lavfi libvmaf=n_subsample=1:log_path={{.ResultFile}}:psnr=1:log_fmt=json:model_path={{.ModelPath}}:n_threads={{.NThreads}} -f null -"
 
 // Measurer is an interface that must be implemented by VQM tool which is capable of
 // calculating Vide Quality Metrics.


### PR DESCRIPTION
MS-SSIM metric calculation is taxing in terms of time, also it does not provide much additional value. If need be it can be enabled via configuration option. For instance:

--8<-- config.json
{
"ffmpeg_vmaf_template": "-hide_banner -i {{.CompressedFile}} -i {{.SourceFile}} -lavfi libvmaf=n_subsample=1:log_path={{.ResultFile}}:ms_ssim=1:psnr=1:log_fmt=json:model_path={{.ModelPath}}:n_threads={{.NThreads}} -f null -" }
--8<--

$ ease <sub-command> -conf config.json

At this point is more valuable to have a default behaviour that takes less time.