### PR TITLE
Fix keyframe data missing from bitrate plot

### DIFF
--- a/internal/analysis/plot.go
+++ b/internal/analysis/plot.go
@@ -616,7 +616,7 @@ func (f *FrameStat) UnmarshalJSON(data []byte) error {
 	}
 
 	switch ps.Flags {
-	case "K_":
+	case "K_", "K__":
 		f.KeyFrame = true
 	default:
 		f.KeyFrame = false

--- a/internal/analysis/plot_test.go
+++ b/internal/analysis/plot_test.go
@@ -217,3 +217,53 @@ func Test_getDuration(t *testing.T) {
 		})
 	}
 }
+
+func Test_FrameStat_UnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		given []byte
+		want  FrameStat
+	}
+
+	tests := map[string]testCase{
+		"2 flags keyframe": {
+			given: []byte(`{"pts_time": "0", "duration_time": "0.04", "size": "82949", "flags": "K_" }`),
+			want: FrameStat{
+				KeyFrame:     true,
+				DurationTime: 0.04,
+				PtsTime:      0,
+				Size:         82949,
+			},
+		},
+		"3 flags keyframe": {
+			given: []byte(`{"pts_time": "0", "duration_time": "0.04", "size": "82949", "flags": "K__" }`),
+			want: FrameStat{
+				KeyFrame:     true,
+				DurationTime: 0.04,
+				PtsTime:      0,
+				Size:         82949,
+			},
+		},
+		"3 flags": {
+			given: []byte(`{"pts_time": "1", "duration_time": "0.04", "size": "82949", "flags": "___" }`),
+			want: FrameStat{
+				KeyFrame:     false,
+				DurationTime: 0.04,
+				PtsTime:      1,
+				Size:         82949,
+			},
+		},
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		var fs FrameStat
+		err := fs.UnmarshalJSON(tc.given)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.want, fs)
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
This was observed with newer ffprobe versions, apparently flags were extended to include also corrupt flag. Added to ffprobe in this commit: https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/18cd65998bfe9651b1bd9496bba9f641c77920cd

Also, adding unittest to cover FrameStat's UnmarshalJSON() method.