### PR TITLE
Release build script also creates Linux arm64 build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -127,9 +127,12 @@ do_release() {
     
     mkdir -p "$RELEASE_DIR"
 
-    # For Linux we create just amd64 arch build
+    # For Linux create both amd64 and arm64 builds
     GOOS=linux GOARCH=amd64 rel_build
     tar --gzip -cvf "${RELEASE_DIR}/${APP_NAME}-linux-amd64.tar.gz" -C "$OUT_DIR" "$APP_NAME"
+
+    GOOS=linux GOARCH=arm64 rel_build
+    tar --gzip -cvf "${RELEASE_DIR}/${APP_NAME}-linux-arm64.tar.gz" -C "$OUT_DIR" "$APP_NAME"
 
     # For macOS create both amd64 and arm64 builds
     GOOS=darwin GOARCH=amd64 rel_build


### PR DESCRIPTION
Add arm64 artefact during release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Linux arm64 builds alongside existing Linux amd64 builds.
  - Linux users can now download release archives compatible with both amd64 and arm64 systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->